### PR TITLE
Fix long approval comment issue

### DIFF
--- a/commands/server moderator/approve.js
+++ b/commands/server moderator/approve.js
@@ -61,7 +61,6 @@ module.exports = {
 				id: 1,
 				created: new Date()
 			}];
-			await dbModify("Suggestion", { suggestionId: id }, qSuggestionDB);
 		}
 
 		let suggester = await fetchUser(qSuggestionDB.suggester, client);

--- a/commands/server moderator/approve.js
+++ b/commands/server moderator/approve.js
@@ -49,13 +49,6 @@ module.exports = {
 			}
 		}
 
-		let suggester = await fetchUser(qSuggestionDB.suggester, client);
-		if (!suggester) return message.channel.send(`<:${emoji.x}> The suggesting user could not be fetched! Please try again.`);
-
-		qSuggestionDB.status = "approved";
-		qSuggestionDB.staff_member = message.author.id;
-		await dbModify("Suggestion", { suggestionId: id }, qSuggestionDB);
-
 		let isComment = args[1];
 
 		let comment;
@@ -70,6 +63,13 @@ module.exports = {
 			}];
 			await dbModify("Suggestion", { suggestionId: id }, qSuggestionDB);
 		}
+
+		let suggester = await fetchUser(qSuggestionDB.suggester, client);
+		if (!suggester) return message.channel.send(`<:${emoji.x}> The suggesting user could not be fetched! Please try again.`);
+
+		qSuggestionDB.status = "approved";
+		qSuggestionDB.staff_member = message.author.id;
+		await dbModify("Suggestion", { suggestionId: id }, qSuggestionDB);
 
 		let replyEmbed = new Discord.MessageEmbed()
 			.setTitle("Suggestion Approved")

--- a/commands/server moderator/massapprove.js
+++ b/commands/server moderator/massapprove.js
@@ -80,8 +80,8 @@ module.exports = {
 					.addField("Result", `**Approved**: ${approvedId.length > 0 ? approvedId.join(", ") : "No suggestions were approved."}\n${notApprovedId.length > 0 ? "**Could Not Approve**: " + notApprovedId.join(", ") : ""}`)
 					.setColor(colors.green)
 					.setFooter(nModified !== su.length
-						? "One or more of your suggestions could not be approved. Please make sure the suggestion IDs you have provided exist and have not already been approved."
-						: "All of your suggestions have been approved."
+						? "One or more of these suggestions could not be approved. Please make sure the suggestion IDs you have provided exist and have not already been approved."
+						: "All of these suggestions have been approved."
 					)
 			);
 		} else {

--- a/commands/server moderator/massdelete.js
+++ b/commands/server moderator/massdelete.js
@@ -80,8 +80,8 @@ module.exports = {
 					.addField("Result", `**Deleted**: ${deniedId.length > 0 ? deniedId.join(", ") : "No suggestions were deleted."}\n${notDeniedId.length > 0 ? "**Could Not Delete**: " + notDeniedId.join(", ") : ""}`)
 					.setColor(colors.green)
 					.setFooter(nModified !== su.length
-						? "One or more of your suggestions could not be deleted. Please make sure the suggestion IDs you have provided exist and have not already been deleted."
-						: "All of your suggestions have been denied."
+						? "One or more of these suggestions could not be deleted. Please make sure the suggestion IDs you have provided exist and have not already been deleted."
+						: "All of these suggestions have been deleted."
 					)
 			);
 		} else {

--- a/commands/server moderator/massdeny.js
+++ b/commands/server moderator/massdeny.js
@@ -82,8 +82,8 @@ module.exports = {
 					.addField("Result", `**Denied**: ${deniedId.length > 0 ? deniedId.join(", ") : "No suggestions were denied."}\n${notDeniedId.length > 0 ? "**Could Not Deny**: " + notDeniedId.join(", ") : ""}`)
 					.setColor(colors.green)
 					.setFooter(nModified !== su.length
-						? "One or more of your suggestions could not be denied. Please make sure the suggestion IDs you have provided exist and have not already been denied."
-						: "All of your suggestions have been denied."
+						? "One or more of these suggestions could not be denied. Please make sure the suggestion IDs you have provided exist and have not already been denied."
+						: "All of these suggestions have been denied."
 					)
 			);
 		} else {


### PR DESCRIPTION
When a comment of length >=1024 is used to approve a suggestion, the suggestion is marked as `approved` despite an error message sent in the channel the command was run in.