### PR TITLE
Add i18n as submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,5 +115,4 @@ commands/test.js
 utils/testSchemas.js
 /persistent.json
 watch.json
-i18n/
 /test.md

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "i18n"]
+	path = i18n
+	url = https://github.com/Suggester-Bot/i18n.git


### PR DESCRIPTION
This adds the i18n repo as a git submodule, which means that
- The i18n dependency is now managed by git, which makes things easier to set up
- Updates to the i18n show up as a commit here, which keeps things consistent across the repos

*Note: you can clone submodules to an existing repo using the command `git submodule update --init`.*