### PR TITLE
Add a .gitattributes file to the repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
Implements a `.gitattributes` file, which will allow Git to automatically convert all line endings (EoLs) to LF. This particular file converts everything to LF, with the exception of Windows-specific file extensions like `.bat` and `.cmd`.

Closes #150 