### PR TITLE
Add `.unfollow auto[matic]`

### DIFF
--- a/commands/other/unfollow.js
+++ b/commands/other/unfollow.js
@@ -1,4 +1,4 @@
-const { dbQuery } = require("../../utils/db");
+const { dbModify, dbQuery } = require("../../utils/db");
 const { checkSuggestion } = require("../../utils/checks");
 const { string } = require("../../utils/strings");
 module.exports = {
@@ -6,7 +6,7 @@ module.exports = {
 		name: "unfollow",
 		permission: 10,
 		aliases: ["unsubscribe", "unsub"],
-		usage: "unfollow [suggestion id]",
+		usage: "unfollow [suggestion id|auto]",
 		description: "Unfollows a suggestion",
 		enabled: true,
 		examples: "`{{p}}unfollow 123`\nUnfollows suggestion #123",
@@ -16,12 +16,19 @@ module.exports = {
 	do: async (locale, message, client, args) => {
 		let qUserDB = await dbQuery("User", { id: message.author.id });
 		if (!args[0]) return message.channel.send(string(locale, "INVALID_SUGGESTION_ID_ERROR", {}, "error"));
-		let [fetchSuggestion, qSuggestionDB] = await checkSuggestion(locale, message.guild, args[0]);
-		if (fetchSuggestion) return message.channel.send(fetchSuggestion);
-		if (!qUserDB.subscribed.find(s => s.id === qSuggestionDB.suggestionId)) return message.channel.send(string(locale, "NOT_FOLLOWING_ERROR", { id: qSuggestionDB.suggestionId }, "error"));
-		let index = qUserDB.subscribed.findIndex(s => s.id === qSuggestionDB.suggestionId);
-		qUserDB.subscribed.splice(index, 1);
-		qUserDB.save();
-		return message.channel.send(string(locale, "UNFOLLOW_SUCCESS", { id: qSuggestionDB.suggestionId }, "success"));
+		if (["auto", "automatic"].includes(args[0].toLowerCase())) {
+			if (!qUserDB.auto_subscribe) return message.channel.send(string(locale, "AUTOFOLLOW_ALREADY_DISABLED", {}, "error"));
+			qUserDB.auto_subscribe = false;
+			await dbModify("User", {id: qUserDB.id}, qUserDB);
+			return message.channel.send(string(locale, "AUTOFOLLOW_DISABLED", {}, "success"));
+		} else {
+			let [fetchSuggestion, qSuggestionDB] = await checkSuggestion(locale, message.guild, args[0]);
+			if (fetchSuggestion) return message.channel.send(fetchSuggestion);
+			if (!qUserDB.subscribed.find(s => s.id === qSuggestionDB.suggestionId)) return message.channel.send(string(locale, "NOT_FOLLOWING_ERROR", { id: qSuggestionDB.suggestionId }, "error"));
+			let index = qUserDB.subscribed.findIndex(s => s.id === qSuggestionDB.suggestionId);
+			qUserDB.subscribed.splice(index, 1);
+			qUserDB.save();
+			return message.channel.send(string(locale, "UNFOLLOW_SUCCESS", { id: qSuggestionDB.suggestionId }, "success"));
+		}
 	}
 };


### PR DESCRIPTION
This adds a subcommand that the bot already [claims it has](https://github.com/Suggester/Suggester/blob/be4bae9d8dc7178994c2e40df4d51edbeb90b425/utils/strings.js#L4567):
> You just upvoted suggestion #{{suggestion}} in **{{server}}**. By default, you're now following this suggestion. This means that if an update is made to the suggestion you will receive a DM. Use `{{prefix}}unfollow {{suggestion}}` in {{server}} to unfollow the suggestion, and `{{prefix}}unfollow auto` to disable automatic following.
_You will only receive this message once_