### PR TITLE
Fix max attachment size

### DIFF
--- a/utils/logs.js
+++ b/utils/logs.js
@@ -47,7 +47,7 @@ module.exports = {
 
 		const img = await fetch(link).then((res) => res.buffer());
 
-		if (img.length >= 1e6) {
+		if (img.length >= 8e6) {
 			return { code: 40005 };
 		}
 


### PR DESCRIPTION
This was mistyped and was supposed to be `8e6` instead of `1e6`. This allows to fully benefit from attachments larger than 8MB.