### PR TITLE
Add "defollow" as an alias for the "unfollow" command

### DIFF
--- a/commands/other/unfollow.js
+++ b/commands/other/unfollow.js
@@ -5,7 +5,7 @@ module.exports = {
 	controls: {
 		name: "unfollow",
 		permission: 10,
-		aliases: ["unsubscribe", "unsub"],
+		aliases: ["unsubscribe", "unsub", "defollow"],
 		usage: "unfollow [suggestion id|auto]",
 		description: "Unfollows a suggestion",
 		enabled: true,


### PR DESCRIPTION
Implements suggestion [#79000](https://canary.discordapp.com/channels/566002482166104066/621433843294928927/759038962739838986) in the Support Server. 

![Suggestion](https://i.imgur.com/u5clQFo.png)