### PR TITLE
Fix string issue in the help command 

### DIFF
--- a/commands/configuration/config.js
+++ b/commands/configuration/config.js
@@ -1114,8 +1114,8 @@ module.exports = {
 		{
 			names: ["commenttime", "commentime", "commenttimestamp", "commenttimestamps", "commentimestamp", "commentimestamps", "ctime"],
 			name: "Comment Timestamps",
-			description: "This setting controls whether or not timestamps are shown for comments in the suggestion embed",
-			examples: "`{{p}}config commenttime on`\nEnables comment timestamps on suggestion embeds\n\n`{{p}}config onevote off`\nDisables comment timestamps on suggestion embeds",
+			description: "This setting controls whether or not timestamps are shown for comments on the suggestion embed",
+			examples: "`{{p}}config commenttime on`\nEnables comment timestamps on suggestion embeds\n\n`{{p}}config commenttime off`\nDisables comment timestamps on suggestion embeds",
 			cfg: async function() {
 				if (!args[1]) return message.channel.send(string(locale, qServerDB.config.comment_timestamps ? "CFG_COMMENT_TIME_ENABLED" : "CFG_COMMENT_TIME_DISABLED"));
 				switch (args[1].toLowerCase()) {

--- a/utils/strings.js
+++ b/utils/strings.js
@@ -44,7 +44,7 @@ module.exports = {
 	list: {
 		"NO_ACK_SET": {
 			string: "No Acknowledgement Set",
-			context: "Shown in the acknowledgement command when no acknowledgement is set for user"
+			context: "Shown in the acknowledgement command when no acknowledgement is set for a user"
 		},
 		"ACK_FILLER_TEXT": {
 			string: "{{user}}'s acknowledgement is: `{{acknowledgement}}`",
@@ -90,7 +90,7 @@ module.exports = {
 		},
 		"NONE_OR_INVALID_STATUS_ERROR": {
 			string: "You provided none or an invalid status. Please choose a reaction below to select a status, or {{x}} to cancel.\n\n>>> **Status List:**\n{{list}}",
-			context: "Error that shows the mark command is run without any status parameter",
+			context: "Error that shows when the mark command is run without any status parameter",
 			replaced: {
 				x: {
 					to_replace: "{{x}}",
@@ -1685,7 +1685,7 @@ module.exports = {
 			context: "Shown when in-channel suggestions are enabled and a guild tries to enable them"
 		},
 		"CFG_INCHANNEL_ALREADY_DISABLED": {
-			string: "Suggestions already cannot be submitted via any message the suggestions feed channel",
+			string: "Suggestions already cannot be submitted via any message in the suggestions feed channel",
 			context: "Shown when in-channel suggestions are disabled and a guild tries to disable them"
 		},
 		"CFG_CLEAR_COMMANDS_ENABLED": {

--- a/utils/strings.js
+++ b/utils/strings.js
@@ -5961,7 +5961,7 @@ module.exports = {
 			context: "Description of the Comment Timestamps config element"
 		},
 		"CONFIG_EXAMPLES:COMMENTTIME": {
-			string: "`{{p}}config commenttime on`\nEnables comment timestamps on suggestion embeds\n\n`{{p}}config onevote off`\nDisables comment timestamps on suggestion embeds",
+			string: "`{{p}}config commenttime on`\nEnables comment timestamps on suggestion embeds\n\n`{{p}}config commenttime off`\nDisables comment timestamps on suggestion embeds",
 			context: "Examples for the Comment Timestamps config element\n" +
 				"Make sure to keep original formatting and not translate actual inputs like `autofollow`"
 		},


### PR DESCRIPTION
This PR fixes the issue reported [here](https://discord.com/channels/566002482166104066/667828646211223553/816422014469668874) in both the configuration and the strings files, and fixes small typos/consistency errors with some strings