### PR TITLE
Fix help links

### DIFF
--- a/commands/other/follow.js
+++ b/commands/other/follow.js
@@ -15,7 +15,7 @@ module.exports = {
 		permissions: ["VIEW_CHANNEL", "SEND_MESSAGES", "USE_EXTERNAL_EMOJIS", "EMBED_LINKS"],
 		cooldown: 5,
 		dmAvailable: true,
-		docs: "following/follow"
+		docs: "topics/follow"
 	},
 	do: async (locale, message, client, args, Discord) => {
 		const qServerDB = message.guild ? await message.guild.db : null;

--- a/commands/other/stats.js
+++ b/commands/other/stats.js
@@ -8,7 +8,9 @@ module.exports = {
 		description: "Shows the link to bot statistics",
 		enabled: true,
 		permissions: ["VIEW_CHANNEL", "SEND_MESSAGES"],
-		cooldown: 20
+		cooldown: 20,
+                docs: "topics/stats" 
+		
 	},
 	do: async (locale, message) => {
 		let chart_link = "https://charts.mongodb.com/charts-suggesterproduction-vredm/public/dashboards/79485b0d-217d-4d7d-9010-429befa016e9";

--- a/commands/other/stats.js
+++ b/commands/other/stats.js
@@ -9,7 +9,7 @@ module.exports = {
 		enabled: true,
 		permissions: ["VIEW_CHANNEL", "SEND_MESSAGES"],
 		cooldown: 20,
-                docs: "topics/stats" 
+		docs: "topics/stats" 
 		
 	},
 	do: async (locale, message) => {

--- a/commands/other/unfollow.js
+++ b/commands/other/unfollow.js
@@ -13,7 +13,7 @@ module.exports = {
 		examples: "`{{p}}unfollow 123`\nUnfollows suggestion #123",
 		permissions: ["VIEW_CHANNEL", "SEND_MESSAGES", "USE_EXTERNAL_EMOJIS"],
 		cooldown: 5,
-		docs: "following/unfollow"
+		docs: "topics/unfollow"
 	},
 	do: async (locale, message, client, args) => {
 		const qServerDB = message.guild ? await message.guild.db : null;

--- a/commands/review/approveedit.js
+++ b/commands/review/approveedit.js
@@ -17,7 +17,7 @@ module.exports = {
 		enabled: true,
 		permissions: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS", "USE_EXTERNAL_EMOJIS"],
 		cooldown: 5,
-		docs: "s/approveedit"
+		docs: "topics/approveedit"
 	},
 	do: async (locale, message, client, args, Discord, noCommand=false) => {
 		let [returned, qServerDB] = await baseConfig(locale, message.guild);

--- a/commands/review/approveedit.js
+++ b/commands/review/approveedit.js
@@ -17,7 +17,7 @@ module.exports = {
 		enabled: true,
 		permissions: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS", "USE_EXTERNAL_EMOJIS"],
 		cooldown: 5,
-		docs: "editing/approveedit"
+		docs: "s/approveedit"
 	},
 	do: async (locale, message, client, args, Discord, noCommand=false) => {
 		let [returned, qServerDB] = await baseConfig(locale, message.guild);

--- a/commands/review/denyedit.js
+++ b/commands/review/denyedit.js
@@ -16,7 +16,7 @@ module.exports = {
 		enabled: true,
 		permissions: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS", "USE_EXTERNAL_EMOJIS"],
 		cooldown: 5,
-		docs: "editing/denyedit"
+		docs: "s/denyedit"
 	},
 	do: async (locale, message, client, args, Discord, noCommand=false) => {
 		let [returned, qServerDB] = await baseConfig(locale, message.guild);

--- a/commands/review/denyedit.js
+++ b/commands/review/denyedit.js
@@ -37,7 +37,7 @@ module.exports = {
 		let suggester = await fetchUser(qSuggestionDB.suggester, client);
 		if (!suggester) return message.channel.send(string(locale, "ERROR", {}, "error")).then(sent => cleanCommand(message, sent, qServerDB));
 
-		let embedReview = reviewEmbed(qServerDB.config.locale, {
+		let embedReview = reviewEmbed(qServerDB.config.locale, { 
 			suggestionId: qSuggestionDB.suggestionId,
 			suggestion: qSuggestionDB.pending_edit.content,
 			submitted: qSuggestionDB.submitted,

--- a/commands/review/denyedit.js
+++ b/commands/review/denyedit.js
@@ -16,7 +16,7 @@ module.exports = {
 		enabled: true,
 		permissions: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS", "USE_EXTERNAL_EMOJIS"],
 		cooldown: 5,
-		docs: "s/denyedit"
+		docs: "topics/denyedit"
 	},
 	do: async (locale, message, client, args, Discord, noCommand=false) => {
 		let [returned, qServerDB] = await baseConfig(locale, message.guild);

--- a/commands/suggestions/asuggest.js
+++ b/commands/suggestions/asuggest.js
@@ -6,11 +6,12 @@ module.exports = {
 		permission: 10,
 		usage: "asuggest",
 		aliases: ["anonsuggest", "anonsuggestions"],
-		description: "Placeholder command for the asuggest slash command",
+		description: "Placeholder command for the `asuggest` slash command",
 		enabled: true,
 		permissions: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"],
 		cooldown: 5,
-		hidden: true
+		hidden: true,
+                docs: "topics/anonymous-suggestions"		
 	},
 	do: async (locale, message, client) => {
 		return message.channel.send(`${string(locale, "ANON_SUGGEST_SLASH_NOTICE")}\n${slash_url.replace("[ID]", client.user.id).slice(0, -1)}&guild_id=${message.guild.id}>`);

--- a/commands/suggestions/edit.js
+++ b/commands/suggestions/edit.js
@@ -18,7 +18,7 @@ module.exports = {
 		examples: "`{{p}}edit 1234 This is an edit suggestion`\nEdits suggestion #1234 to have the content of \"This is an edit suggestion\"",
 		permissions: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS", "USE_EXTERNAL_EMOJIS"],
 		cooldown: 20,
-		docs: "editing/suggestion-editing"
+		docs: "topics/suggestion-editing"
 	},
 	do: async (locale, message, client, args, Discord, noCommand=false) => {
 		let qServerDB = await dbQuery("Server", { id: message.guild.id });

--- a/commands/suggestions/editcomment.js
+++ b/commands/suggestions/editcomment.js
@@ -17,7 +17,7 @@ module.exports = {
 		examples: "`{{p}}editcomment 27_1 This is new content`\nEdits a comment with the ID `27_1` to read \"This is new content\"",
 		permissions: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS", "USE_EXTERNAL_EMOJIS"],
 		cooldown: 10,
-		docs: "/comment-editing"
+		docs: "topics/comment-editing"
 	},
 	do: async (locale, message, client, args, Discord) => {
 		let [returned, qServerDB] = await baseConfig(locale, message.guild);

--- a/commands/suggestions/editcomment.js
+++ b/commands/suggestions/editcomment.js
@@ -17,7 +17,7 @@ module.exports = {
 		examples: "`{{p}}editcomment 27_1 This is new content`\nEdits a comment with the ID `27_1` to read \"This is new content\"",
 		permissions: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS", "USE_EXTERNAL_EMOJIS"],
 		cooldown: 10,
-		docs: "editing/comment-editing"
+		docs: "/comment-editing"
 	},
 	do: async (locale, message, client, args, Discord) => {
 		let [returned, qServerDB] = await baseConfig(locale, message.guild);

--- a/commands/suggestions/search.js
+++ b/commands/suggestions/search.js
@@ -13,7 +13,8 @@ module.exports = {
 		enabled: true,
 		examples: "`{{p}}search status:approved author:327887845270487041`\nSearches for approved suggestions created by user 327887845270487041\n\n`{{p}}search mark:\"in progress\" staff:702180584503508994`\nSearches for suggestions marked as \"In Progress\" that were approved by user 702180584503508994\n\n`{{p}}search votes>10 time>\"1 month\" content!\"test\"`\nSearches for suggestions with more than 10 votes, more than a month old, and with a content not including \"test\"",
 		permissions: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS", "USE_EXTERNAL_EMOJIS"],
-		cooldown: 5
+		cooldown: 5,
+		docs: "topics/search"
 	},
 	do: async (locale, message, client, args, Discord) => {
 		let [returned, qServerDB] = await baseConfig(locale, message.guild);

--- a/commands/suggestions/shortinfo.js
+++ b/commands/suggestions/shortinfo.js
@@ -12,7 +12,8 @@ module.exports = {
 		enabled: true,
 		examples: "`{{p}}shortinfo 1`\nShows information about suggestion #1\n\n`{{p}}shortinfo 1 -trim-suggest`\nShows information about suggestion #1 limiting the suggestion content to 250 characters\n\n`{{p}}shortinfo 1 -no-attach`\nShows information about suggestion #1 without showing the added attachment",
 		permissions: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS", "USE_EXTERNAL_EMOJIS"],
-		cooldown: 5
+		cooldown: 5,
+		docs: "topics/shortinfo"
 	},
 	do: async (locale, message, client, args, Discord) => {
 		let [returned, qServerDB] = await baseConfig(locale, message.guild);


### PR DESCRIPTION
Some hyperlinks in the help command broke due the latest documentation update reducing the amount of folders and thus relative file paths 