### PR TITLE
Remove "suggestion" alias

### DIFF
--- a/commands/suggestions/info.js
+++ b/commands/suggestions/info.js
@@ -7,7 +7,7 @@ module.exports = {
 		name: "info",
 		permission: 3,
 		usage: "info [suggestion id]",
-		aliases: ["details", "suggestion"],
+		aliases: ["details"],
 		description: "Shows information about a suggestion",
 		image: "images/Info.gif",
 		enabled: true,

--- a/commands/suggestions/suggest.js
+++ b/commands/suggestions/suggest.js
@@ -15,7 +15,7 @@ module.exports = {
 	controls: {
 		name: "suggest",
 		permission: 10,
-		aliases: ["submit"],
+		aliases: ["submit", "suggestion"],
 		usage: "suggest [suggestion]",
 		description: "Submits a suggestion",
 		image: "images/Suggest.gif",


### PR DESCRIPTION
This removes the "suggestion" alias from the `.info` command and adds it to the `.suggest` command as people usually tries to use it to submit a suggestion instead of looking for info about one, and get confused by an Invalid Suggestion ID error.